### PR TITLE
Patch to support "statuses/filter" method of Twitter Stream API

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -205,7 +205,6 @@ Twitter.prototype.stream = function(method, params, callback) {
 			params.follow = params.follow.join(',')
 		}
 	} else if (method === 'statuses/filter') {
-                stream_base = this.options.site_stream_base;
 		// Workaround for node-oauth vs. twitter double-encode-commas bug
 		if ( params && params.follow && Array.isArray(params.follow) ) {
 			params.follow = params.follow.join(',')

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -204,9 +204,13 @@ Twitter.prototype.stream = function(method, params, callback) {
 		if ( params && params.follow && Array.isArray(params.follow) ) {
 			params.follow = params.follow.join(',')
 		}
-	}
-
-
+	} else if (method === 'statuses/filter') {
+                stream_base = this.options.site_stream_base;
+		// Workaround for node-oauth vs. twitter double-encode-commas bug
+		if ( params && params.follow && Array.isArray(params.follow) ) {
+			params.follow = params.follow.join(',')
+		}
+        }
 	var url = stream_base + '/' + escape(method) + '.json';
 
 	var request = this.oauth.post(url + '?' + querystring.stringify(params),

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -205,9 +205,9 @@ Twitter.prototype.stream = function(method, params, callback) {
 			params.follow = params.follow.join(',')
 		}
 	} else if (method === 'statuses/filter') {
-		// Workaround for node-oauth vs. twitter double-encode-commas bug
-		if ( params && params.follow && Array.isArray(params.follow) ) {
-			params.follow = params.follow.join(',')
+		// Workaround for node-oauth vs. twitter commas-in-params bug
+		if ( params && params.track && Array.isArray(params.track) ) {
+			params.track = params.track.join(',')
 		}
         }
 	var url = stream_base + '/' + escape(method) + '.json';

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -1,8 +1,8 @@
-var	VERSION = '0.1.17',
+var	VERSION = '0.2.0',
 	http = require('http'),
 	querystring = require('querystring'),
 	oauth = require('oauth'),
-	cookie = require('cookie'),
+	cookie = require('cookies'),
 	streamparser = require('./parser');
 
 function merge(defaults, options) {
@@ -94,7 +94,7 @@ Twitter.prototype.get = function(url, params, callback) {
 		} else {
 			try {
 				var json = JSON.parse(data);
-				callback(json);
+				callback(null, json);
 			} catch(err) {
 				callback(err);
 			}
@@ -148,7 +148,7 @@ Twitter.prototype.post = function(url, content, content_type, callback) {
 		} else {
 			try {
 				var json = JSON.parse(data);
-				callback(json);
+				callback(null, json);
 			} catch(err) {
 				callback(err);
 			}
@@ -205,11 +205,16 @@ Twitter.prototype.stream = function(method, params, callback) {
 			params.follow = params.follow.join(',')
 		}
 	} else if (method === 'statuses/filter') {
-		// Workaround for node-oauth vs. twitter commas-in-params bug
+		// Workaround for node-oauth vs. twitter double-encode-commas bug
 		if ( params && params.track && Array.isArray(params.track) ) {
 			params.track = params.track.join(',')
 		}
-        }
+		if ( params && params.follow && Array.isArray(params.follow) ) {
+			params.follow = params.follow.join(',')
+		}
+	}
+
+
 	var url = stream_base + '/' + escape(method) + '.json';
 
 	var request = this.oauth.post(url + '?' + querystring.stringify(params),
@@ -553,9 +558,11 @@ Twitter.prototype.userProfileImage = function(id, params, callback) {
 		this.options.access_token_secret);
 	request.on('response', function(response) {
 		// return the location or an HTTP error
-		callback(response.headers.location || new Error('HTTP Error '
+		if (!response.headers.location) { 
+			callback(new Error('HTTP Error '
 			+ response.statusCode + ': '
-			+ http.STATUS_CODES[response.statusCode]));
+			+ http.STATUS_CODES[response.statusCode])) }
+		callback(null, response.headers.location);
 	});
 	request.end();
 
@@ -1126,7 +1133,7 @@ Twitter.prototype._getUsingCursor = function(url, params, callback) {
 		if (data[key]) result = result.concat(data[key]);
 
 		if (data.next_cursor_str === '0') {
-			callback(result);
+			callback(null, result);
 		} else {
 			params.cursor = data.next_cursor_str;
 			self.get(url, params, fetch);

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
-{ "name": "twitter"
-, "version": "v0.1.17"
+{ "name": "ntwitter"
+, "version": "v0.2.0"
 , "description": "Asynchronous Twitter REST/stream/search client API for node.js."
 , "keywords": ["twitter","streaming","oauth"]
-, "homepage": "https://github.com/jdub/node-twitter"
-, "author": "jdub"
+, "homepage": "https://github.com/AvianFlu/ntwitter"
+, "author": "jdub, changes by AvianFlu"
 , "licenses":
   [ { "type": "MIT"
-    , "url": "http://github.com/jdub/node-twitter/raw/master/LICENSE"
+    , "url": "http://github.com/AvianFlu/ntwitter/raw/master/LICENSE"
   } ]
 , "repository":
   { "type": "git"
-  , "url": "http://github.com/jdub/node-twitter.git"
+  , "url": "http://github.com/AvianFlu/ntwitter.git"
   }
 , "dependencies":
   { "oauth": ">=0.8.4"
-  , "cookie": ">=0.1.4"
+  , "cookies": "0.1.x"
   }
-, "engines": ["node >=0.2.0"]
+, "engines": ["node 0.4.x"]
 , "main": "./lib/twitter"
 }


### PR DESCRIPTION
I use node-twitter in an IRC bot (https://github.com/nodejitsu/kohai) that pipes selected tweets to selected IRC rooms, and several users have asked for the ability to only follow search terms, rather than their friends, to cut down on the number of tweets that wind up in chat.  The answer to this is to use `statuses/filter` rather than `user` as the stream type - this patch adds support for that method.  

(Sorry it's 3 commits, I'm still a bit of a git noob.  Only the last commit is the important one.)  
