### PR TITLE
Stream param list exceeds URL length

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -40,7 +40,7 @@ function Twitter(options) {
 
 		rest_base: 'https://api.twitter.com/1',
 		search_base: 'http://search.twitter.com',
-		stream_base: 'http://stream.twitter.com/1',
+		stream_base: 'https://stream.twitter.com/1',
 		user_stream_base: 'https://userstream.twitter.com/2',
 		site_stream_base: 'http://sitestream.twitter.com/2b',
 

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -209,9 +209,10 @@ Twitter.prototype.stream = function(method, params, callback) {
 
 	var url = stream_base + '/' + escape(method) + '.json';
 
-	var request = this.oauth.post(url + '?' + querystring.stringify(params),
+	var request = this.oauth.post(url,
 		this.options.access_token_key,
-		this.options.access_token_secret);
+		this.options.access_token_secret,
+		params);
 
 	var stream = new streamparser();
 	stream.destroy = function() {


### PR DESCRIPTION
We're using the streaming API to follow several hundred users and have encountered the URL length limit. In this fork I've moved the params for the POST from the URL to the body of the post and this seems to work for our case. Hope it's helpful.
