### PR TITLE
Streaming API changed to SSL only

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -39,10 +39,10 @@ function Twitter(options) {
 		authorize_url: 'https://api.twitter.com/oauth/authorize',
 
 		rest_base: 'https://api.twitter.com/1',
-		search_base: 'http://search.twitter.com',
-		stream_base: 'http://stream.twitter.com/1',
+		search_base: 'https://search.twitter.com',
+		stream_base: 'https://stream.twitter.com/1',
 		user_stream_base: 'https://userstream.twitter.com/2',
-		site_stream_base: 'http://sitestream.twitter.com/2b',
+		site_stream_base: 'https://sitestream.twitter.com/2b',
 
 		secure: false, // force use of https for login/gatekeeper
 		cookie: 'twauth',


### PR DESCRIPTION
The streaming API has turned SSL only, so if 'http' is used then the
connection is refused by Twitter. See
https://dev.twitter.com/blog/streaming-api-turning-ssl-only-september-29th
for more details.

I've only tested this using vanilla streaming - so no testing on user streams, site streams or searches.
