### PR TITLE
Sitestreams endpoint appears to be SSL only

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -42,7 +42,7 @@ function Twitter(options) {
 		search_base: 'http://search.twitter.com',
 		stream_base: 'http://stream.twitter.com/1',
 		user_stream_base: 'https://userstream.twitter.com/2',
-		site_stream_base: 'http://sitestream.twitter.com/2b',
+		site_stream_base: 'https://sitestream.twitter.com/2b',
 
 		secure: false, // force use of https for login/gatekeeper
 		cookie: 'twauth',


### PR DESCRIPTION
Sitestreams endpoint appears to be SSL only (per https://dev.twitter.com/docs/streaming-api/site-streams#API_Overview_)
