### PR TITLE
Correction of method getRetweets

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -481,7 +481,7 @@ Twitter.prototype.retweetStatus = function(id, callback) {
 
 Twitter.prototype.getRetweets = function(id, params, callback) {
 	var url = '/statuses/retweets/' + escape(id) + '.json';
-	this.post(url, params, null, callback);
+	this.get(url, params, callback);
 	return this;
 }
 


### PR DESCRIPTION
This method uses GET instead of POST.
